### PR TITLE
Hide Tests When this library is a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 set(CONAN_EXTRA_REQUIRES "")
 set(CONAN_EXTRA_OPTIONS "")
 
+
 set(CONAN_EXTRA_REQUIRES ${CONAN_EXTRA_REQUIRES})
 include(cmake/Conan.cmake)
 run_conan()
@@ -59,12 +60,17 @@ add_subdirectory(include)
 add_library(athena::athena ALIAS athena)
 
 # Enable catch2 Testing
-if(ENABLE_TESTING)
-    enable_testing()
-    message(
-            "Building Unit Tests."
-    )
-    add_subdirectory(unit_tests PRIVATE)
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+    set(ATHENA_ENABLE_TESTING TRUE)
 endif()
 
+if(ATHENA_ENABLE_TESTING)
+    if(ENABLE_TESTING)
+        enable_testing()
+        message(
+                "Building Unit Tests."
+        )
+        add_subdirectory(unit_tests PRIVATE)
+    endif()
 #todo: Add fuzz testing~
+endif()


### PR DESCRIPTION
**Overview:**
Currently projects including this (mainly Hestia game engine) are building the Athena tests as part of its own unit tests. This work is to add a check to only allow the Athena unit tests to run if the Athena project is the current project and make sure it does not run the Athena tests as a sub module. Optionally the tests can be included in other projects.

**Changes Made:**
- Added athena_unit_tests cmake parameter wrapping the tests.
- Added if statement to compare the current cmake directory to the source directory.
- Set athena_unit_tests if the source directory is the current directory.

**Testing considerations:**
- None added, cmake check added.
